### PR TITLE
Fix docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ features = [
     "Win32_Security",
     "Win32_UI_Input_XboxController",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]


### PR DESCRIPTION
Since v0.1.9 and the windows crate bump to v0.59.0, docs.rs fails to build the Linux target. Since this is a Windows-only crate anyway, ensure it only builds for that platform, as described here: https://docs.rs/about/metadata