### PR TITLE
Fix dump_memory() and get_modules()

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -47,7 +47,6 @@ const STILL_ACTIVE: u32 = 259;
 pub struct Process
 {
     main_module: Option<ProcessModule>, //cache for pattern scans
-    modules: Vec<ProcessModule>, //cache for pattern scans
     process_data: Rc<RefCell<ProcessData>>
 }
 
@@ -67,7 +66,6 @@ impl Process
         Process
         {
             main_module: None,
-            modules: Vec::new(),
             process_data: Rc::new(RefCell::new(ProcessData
             {
                 name: String::from(name),
@@ -97,7 +95,6 @@ impl Process
         Process
         {
             main_module: None,
-            modules: Vec::new(),
             process_data: Rc::new(RefCell::new(ProcessData
             {
                 name: String::from(name),
@@ -164,10 +161,9 @@ impl Process
     }
 
     ///returns a copy of all modules
-    pub fn get_modules(&mut self) -> Vec<ProcessModule>
+    pub fn get_modules(&self) -> Vec<ProcessModule>
     {
-        self.modules = Process::get_process_modules(self.process_data.borrow().handle.clone(), &self.process_data);
-        self.modules.clone()
+        return Process::get_process_modules(self.process_data.borrow().handle.clone(), &self.process_data);
     }
     ///returns if the process is using win32 API's to read/write memory
     pub fn get_memory_type(&self) -> MemoryType

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -164,8 +164,9 @@ impl Process
     }
 
     ///returns a copy of all modules
-    pub fn get_modules(&self) -> Vec<ProcessModule>
+    pub fn get_modules(&mut self) -> Vec<ProcessModule>
     {
+        self.modules = Process::get_process_modules(self.process_data.borrow().handle.clone(), &self.process_data);
         self.modules.clone()
     }
     ///returns if the process is using win32 API's to read/write memory

--- a/src/process/refresh.rs
+++ b/src/process/refresh.rs
@@ -99,8 +99,7 @@ impl Process
                                 let mut wow64 = FALSE;
                                 if IsWow64Process(handle, &mut wow64).is_ok()
                                 {
-                                    let mut modules = Process::get_process_modules(handle, &self.process_data);
-                                    let mut main_module = modules.remove(0);
+                                    let mut main_module = Process::get_process_modules(handle, &self.process_data).remove(0);
                                     main_module.dump_memory(handle);
 
                                     let mut process_data = self.process_data.borrow_mut();
@@ -113,7 +112,6 @@ impl Process
                                     process_data.attached = true;
 
                                     self.main_module = Some(main_module);
-                                    self.modules = modules;
 
                                     return Ok(());
                                 }

--- a/src/process/refresh.rs
+++ b/src/process/refresh.rs
@@ -55,11 +55,6 @@ impl Process
                 return Err(String::from("Process exited"));
             }
 
-            if self.process_data.borrow().attached
-            {
-                return Ok(());
-            }
-
             //Look for a running process with the correct name and attach to it
             let mut process_ids = [0u32; 2048];
             let mut out_size = 0;

--- a/src/process/refresh.rs
+++ b/src/process/refresh.rs
@@ -101,7 +101,7 @@ impl Process
                                 {
                                     let mut modules = Process::get_process_modules(handle, &self.process_data);
                                     let mut main_module = modules.remove(0);
-                                    main_module.dump_memory();
+                                    main_module.dump_memory(handle);
 
                                     let mut process_data = self.process_data.borrow_mut();
 

--- a/src/process/refresh.rs
+++ b/src/process/refresh.rs
@@ -55,6 +55,11 @@ impl Process
                 return Err(String::from("Process exited"));
             }
 
+            if self.process_data.borrow().attached
+            {
+                return Ok(());
+            }
+
             //Look for a running process with the correct name and attach to it
             let mut process_ids = [0u32; 2048];
             let mut out_size = 0;

--- a/src/process_module/mod.rs
+++ b/src/process_module/mod.rs
@@ -19,6 +19,7 @@ mod read_write;
 use std::cell::RefCell;
 use std::mem;
 use std::rc::Rc;
+use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::Diagnostics::Debug::{IMAGE_NT_HEADERS32, IMAGE_NT_HEADERS64};
 use windows::Win32::System::SystemServices::{IMAGE_DOS_HEADER, IMAGE_EXPORT_DIRECTORY};
 use crate::memory::{BaseReadWrite, ReadWrite};
@@ -64,15 +65,14 @@ impl ProcessModule
         ProcessModule { process_data, id, path, name, base_address: base, size, memory: Vec::new() }
     }
 
-    pub fn dump_memory(&mut self)
+    pub fn dump_memory(&mut self, process_handle: HANDLE)
     {
         let mut buffer: Vec<u8> = vec![0; self.size];
-        if !self.read_memory_abs(self.base_address, &mut buffer)
+        if !self.read_with_handle(process_handle, self.process_data.borrow().memory_type.clone(), self.base_address, &mut buffer)
         {
             return;
         }
         self.memory = buffer;
-
     }
 
     pub fn get_exports(&self) -> Vec<(String, usize)>


### PR DESCRIPTION
This fixes 2 issues I noticed with mem-rs 0.2.2 after updating to it in SoulsTAS.

- Memory scans don't work, which is caused by dump_memory() in refresh() failing due to it being called before the process handle is stored in process_data. I simply reverted back to how it was done in 0.2.0, which means passing the handle to dump_memory() directly.
- get_modules() always returns the module list from when the process was first attached. That's because refresh() was only allowed to be run once and future calls simply don't actually refresh, which I changed. I'm unsure why that was there in the first place, so please lmk if that has unintended side-effects.